### PR TITLE
regex for consistent string in all save files now more succinct

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,8 +8,8 @@ $(function(){
         var fromVal = from.val();
         var toVal = to.val();
         if (fromVal.length > 10 && toVal.length > 10) {
-            var fromCompSave = fromVal.match(/eyAibWFwTW9kIjo.*/);
-            var toCompID = toVal.match(/^(.*)eyAibWFwTW9kIjo/);
+            var fromCompSave = fromVal.match(/eyAi.*/);
+            var toCompID = toVal.match(/^(.*)eyAi/);
             if (fromCompSave && toCompID) {
                 result.val(toCompID[1]+fromCompSave[0]);
                 error.hide();


### PR DESCRIPTION
I found that the consistent string across save files, "eyAibWFwTW9kIjo", actually was too greedy and didn't match a Windows->Mac conversion I was doing as the string beyond "eyAi" differed between the two save files. The string "eyAi" was the consistent part that was needed, and a manual copy/paste worked, so I'm thinking it's a better fit. I have not tested this beyond my use case, so I can't guarantee it 100% works on all cases ;)