### PR TITLE
Make regex non-greedy in case eyAi is duplicated

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,7 @@ $(function(){
         var toVal = to.val();
         if (fromVal.length > 10 && toVal.length > 10) {
             var fromCompSave = fromVal.match(/eyAi.*/);
-            var toCompID = toVal.match(/^(.*)eyAi/);
+            var toCompID = toVal.match(/^(.*?)eyAi/);
             if (fromCompSave && toCompID) {
                 result.val(toCompID[1]+fromCompSave[0]);
                 error.hide();


### PR DESCRIPTION
There is roughly a 1 in 3000 chance of the magic string "eyAi" appearing more than once in the savegame file (assuming uniform random base64 files of 6KB). In that case, we want the capture group to match the first part only.